### PR TITLE
중복된 문장이 있을 경우 chunking 오류 수정

### DIFF
--- a/kss/kss.py
+++ b/kss/kss.py
@@ -347,11 +347,14 @@ def split_sentences(text: str):
 
 
 def split_sentences_index(text) -> List[SentenceIndex]:
-    def get_sentence_index(sentence):
-        return SentenceIndex(text.index(sentence), text.index(sentence) + len(sentence))
-
     sentences = split_sentences(text)
-    return [get_sentence_index(sentence) for sentence in sentences]
+    sentence_indexes = []
+    offset = 0
+    for sentence in sentences:
+        sentence_indexes.append(SentenceIndex(offset + text.index(sentence), offset + text.index(sentence) + len(sentence)))
+        offset += text.index(sentence) + len(sentence)
+        text = text[text.index(sentence) + len(sentence):]
+    return sentence_indexes
 
 
 def split_chunks(text: str, max_length=128, overlap=False, indexes=None) -> List[ChunkWithIndex]:


### PR DESCRIPTION
안녕하세요!

chunking 과정 중 중복된 문장이 있으면 위치 정보를 제대로 가져오지 못하는 현상이 있어 수정하였습니다.

수정 이전 : 

![image](https://user-images.githubusercontent.com/237049/102980568-1e691900-454b-11eb-9ff1-476c5bbc9129.png)

수정 이후 : 

![image](https://user-images.githubusercontent.com/237049/102980575-21fca000-454b-11eb-938a-767bb64af158.png)

반영 부탁드립니다. ^^