### PR TITLE
Add `regex` dependency for pynori.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup, find_packages
 
 required = [
     "emoji",
+    "regex",
 ]
 
 


### PR DESCRIPTION
`pynori` 안쪽에서 `regex` 모듈을 import 하고 있어서 `pip install kss` 만으로는 기본값으로 작동이 잘 되지 않습니다. 이에 `emoji` 모듈에 더하여 `regex` 모듈도 dependency 로 설정해 주시면 좋을 거 같습니다.