### PR TITLE
Update logger.py

### DIFF
--- a/kss/_utils/logger.py
+++ b/kss/_utils/logger.py
@@ -6,7 +6,7 @@ import logging
 from logging import getLogger
 
 logging.basicConfig(format="[Kss]: %(message)s", level=logging.WARNING)
-logger = getLogger()
+logger = getLogger("Kss")
 
 
 def highlight_diffs(old, new):


### PR DESCRIPTION
라이브러리에서 루트 로거를 사용하면,
사용자 제어가 어려워 라이브러리 로거를 사용하길 권장합니다.