### PR TITLE
Upgrade PyYAML version to 6.0.2 for python 3.12 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ with open("README.md", encoding="utf-8") as f:
 
 install_requires = [
     "emoji==1.2.0", "pecab", "networkx", "jamo",
-    "hangul-jamo", "tossi", "distance", "pyyaml==6.0",
+    "hangul-jamo", "tossi", "distance", "pyyaml>=6.0.2",
     "unidecode", "cmudict", "koparadigm", "kollocate",
     "bs4", "numpy", "pytest", "scipy",
 ]


### PR DESCRIPTION
Update PyYAML dependency from `6.0` to `6.0.2` in setup.py to fix installation issues on Python 3.12

close https://github.com/hyunwoongko/kss/issues/77