### PR TITLE
Remove auto-installation of mecab in setup.py to prevent password prompt during pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Kss is a Korean string processing suite that provides various functions for proc
 - August 16, 2019 [Released Kss 1.0 C++](https://docs.likejazz.com/kss/).
 
 ## Installation
+> **⚠️ Note (2025-08-01):**
+> 
+> The automatic installation of mecab and related Python packages has been removed from `setup.py` to prevent password prompts and privilege escalation during installation. 
+> 
+> If you require mecab functionality, please install mecab and its Python bindings manually before installing or using KSS. See below for instructions.
+
 ### Install Kss
 Kss can be easily installed using the pip package manager.
 ```console

--- a/setup.py
+++ b/setup.py
@@ -27,34 +27,8 @@ How pip install works:
 
 class PreInstall(install):
     def run(self):
-        try:
-            # 1. Try to import mecab
-            import mecab
-        except:
-            try:
-                # 2. Try to install python-mecab-kor and import mecab again
-                with suppress():
-                    subprocess.call(
-                        [sys.executable, "-m", "pip", "install", "python-mecab-kor"],
-                        stderr=subprocess.DEVNULL,
-                    )
-
-                import mecab
-            except:
-                try:
-                    # 3. Try to install python-mecab-ko and import mecab again
-                    with suppress():
-                        inst = "curl -s https://raw.githubusercontent.com/konlpy/konlpy/master/scripts/mecab.sh | bash > /dev/null 2>&1"
-                        os.system(inst)
-                        subprocess.call(
-                            [sys.executable, "-m", "pip", "install", "python-mecab-ko"],
-                            stderr=subprocess.DEVNULL,
-                        )
-                    import mecab
-                except:
-                    # 4. Cannot install mecab.
-                    pass
-
+        # Disabled auto-installation of mecab and related packages to avoid privilege escalation and password prompts.
+        # Please install mecab and its Python bindings manually if needed.
         super().run()
 
 


### PR DESCRIPTION
## Summary
This PR removes the automatic installation of mecab and related Python packages from `setup.py`. Previously, the installation process attempted to install system-level dependencies and Python packages, which could trigger password prompts (e.g., for sudo) during `pip install`, even inside virtual environments.

## Motivation
- Fixes the issue where `pip install kss` or `pip install .` prompts for a password on macOS and Ubuntu, both inside and outside of virtual environments.
- Prevents privilege escalation and respects Python packaging best practices.

## Details
- The `PreInstall` class in `setup.py` no longer attempts to install mecab or its Python bindings automatically.
- Users are now expected to install mecab and its Python bindings manually if needed.

## Additional Notes
- No changes to the core functionality of kss.
- Please update documentation to clarify mecab installation requirements if necessary.

Closes: #<issue_number_if_known>

---
_No pull request template was found in the repository. If a template exists elsewhere, please let me know and I will update the PR description accordingly._